### PR TITLE
Set the chunked flag on recycled InputNetworkStreamWrapper correctly

### DIFF
--- a/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
@@ -1809,10 +1809,7 @@ namespace System.Net
                 response = new HttpWebResponse(m_method, m_originalUrl, respData, this);
                 
                 // Now we look if response has chunked encoding. If it is chunked, we need to set flag in m_requestStream we return.
-                if (respData.m_chunked)
-                {
-                    m_requestStream.m_EnableChunkedDecoding = true;
-                }
+                m_requestStream.m_EnableChunkedDecoding = respData.m_chunked;
 
                 // Currently the request and response are the same network streams, but we optimize later.
                 response.SetResponseStream(m_requestStream);


### PR DESCRIPTION
When a InputNetworkStreamWrapper is reused, the chunked flag needs to be set to reflect the current request. If the instance is used for chunked data and afterwards is used for non chunked data, the flag remained set.

Signed-off-by: Klaus Vancamelbeke (klaus@proles.be)

<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
InputNetworkStreamWrapper instances are reused from a pool for requests to the same host.
The chunked flag m_EnableChunkedDecoding on InputNetworkStreamWrapper is set depending on the Transfer-Encoding header. However if the flag is set by a request, all following requests do not reset the flag. Requests that return non chunked data are still considered as chunked and do not return until the timeout occurs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes nanoFramework/Home#987

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
