### PR TITLE
Fix HttpClient.Post error on subsequent call

### DIFF
--- a/nanoFramework.System.Net.Http/Http/HttpClientHandler.cs
+++ b/nanoFramework.System.Net.Http/Http/HttpClientHandler.cs
@@ -262,8 +262,6 @@ namespace System.Net.Http
             {
                 throw new HttpRequestException("An error occurred while sending the request", ex);
             }
-
-            _sentRequest = false;
             
             return CreateResponseMessage(wresponse, request);
         }
@@ -306,7 +304,7 @@ namespace System.Net.Http
                 wr.Timeout = (int)_timeout.TotalMilliseconds;
             }
 
-            wr.SslProtocols = SslProtocols;
+            wr.SslProtocols = _sslProtocols;
             wr.HttpsAuthentCert = _caCert;
 
             if (ClientCertificateOptions == ClientCertificateOption.Manual)
@@ -386,7 +384,7 @@ namespace System.Net.Http
 
         internal void SetWebRequestSslProcol(SslProtocols sslProtocols)
         {
-            SslProtocols = sslProtocols;
+            _sslProtocols = sslProtocols;
         }
 
         internal void SetWebRequestHttpAuthCert(X509Certificate certificate)

--- a/nanoFramework.System.Net.Http/Http/HttpClientHandler.cs
+++ b/nanoFramework.System.Net.Http/Http/HttpClientHandler.cs
@@ -263,6 +263,8 @@ namespace System.Net.Http
                 throw new HttpRequestException("An error occurred while sending the request", ex);
             }
 
+            _sentRequest = false;
+            
             return CreateResponseMessage(wresponse, request);
         }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Replace access to properties with fields in internal methods and code.

## Motivation and Context
- Fixes nanoFramework/Home#1112.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Test using [Test Code](https://github.com/ddeters76/HttpClientFail)
- Addtional Test using a loop
- No memory leaks after multiple post calls to same uri.

```
  _httpClient.BaseAddress = new Uri("http://httpbin.org/anything");

  for (int i = 1; i < 30; i++)
  {
     var content = new StringContent("{\"someProperty\":\"someValue\"}", Encoding.UTF8, "application/json");
     var result = _httpClient.Post("", content);
     result.EnsureSuccessStatusCode();
     Thread.Sleep(1_000);
   } 
```

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
