### PR TITLE
Instruct HttpListener to start with a specified network interface

### DIFF
--- a/nanoFramework.System.Net.Http/Http/System.Net.HttpListener.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net.HttpListener.cs
@@ -462,16 +462,37 @@ namespace System.Net
         /// </remarks>
         public void Start()
         {
+            IPAddress addr = IPAddress.GetDefaultLocalAddress();
+            Start(addr.ToString());
+        }
+
+        /// <summary>
+        /// Allows this instance to receive incoming requests.
+        /// </summary>
+        /// <param name="niIpAddress">
+        /// IP address of the intended network interface.
+        /// If there are several available network interfaces, such as Ethernet, SoftAp, and WiFi, 
+        /// you can target a specific one.
+        /// </param>
+        /// <remarks>This method must be called before you call the
+        /// <see cref="GetContext"/> method.   If
+        /// the service was already started, the call has no effect.  After you
+        /// have started an <itemref>HttpListener</itemref> object, you can use
+        /// the <see cref='Stop'/> method to stop it.
+        /// </remarks>
+        /// <summary>
+        public void Start(string niIpAddress)
+        {
             lock (lockObj)
             {
                 if (m_Closed) throw new ObjectDisposedException();
-                
+
                 // If service was already started, the call has no effect.
                 if (m_ServiceRunning)
                 {
                     return;
                 }
-                
+
                 m_listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
                 try
@@ -494,7 +515,7 @@ namespace System.Net
                     // empty on purpose
                 }
 
-                IPAddress addr = IPAddress.GetDefaultLocalAddress();
+                IPAddress addr = IPAddress.Parse(niIpAddress);
 
                 IPEndPoint endPoint = new IPEndPoint(addr, m_Port);
                 m_listener.Bind(endPoint);
@@ -510,6 +531,7 @@ namespace System.Net
                 m_RequestArrived.WaitOne();
             }
         }
+
 
         /// <summary>
         /// Shuts down the <itemref>HttpListener</itemref> after processing all
@@ -544,7 +566,7 @@ namespace System.Net
         /// has no effect.
         /// <para>
         /// After you have stopped an <itemref>HttpListener</itemref> object,
-        /// you can use the <see cref='Start'/> method
+        /// you can use the <see cref='Start(string)'/> method
         /// to restart it.
         /// </para>
         /// </remarks>


### PR DESCRIPTION
## Description
- IP address string was added to override the Start call, allowing the user to select a specific network interface.
- Original Start call will now call the new one with the IP address string obtained from GetDefaultLocalAddress call. 

## Motivation and Context
The default network interface was selected during the initial Start call in order to listen. If you only have one network interface, this is acceptable. However, there may be a need to bind to a particular interface, such as SoftAP, if you have various network interfaces, including Ethernet, Wifi, SoftAP, and others. An IP address string was now added to the overridden Start call so that the user could pick a particular network interface.
After acquiring the default network interface like previously, the original Start calls the new one. Backward compatibility is thus maintained.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
I have tested and verify the code in my local app that exposes a WEB page to configure Wifi parameters.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
