### PR TITLE
Add support for HTTP/1.0 responses without 'Content-Lenght' header

### DIFF
--- a/nanoFramework.System.Net.Http/Http/StreamContent.cs
+++ b/nanoFramework.System.Net.Http/Http/StreamContent.cs
@@ -96,21 +96,18 @@ namespace System.Net.Http
                 }
             }
 
-            while (totalRead < contentLength)
+            bool isDone = false;
+            while ((totalRead < contentLength) && !isDone)
             {
                 read = _content.Read(buffer, 0, buffer.Length);
+                isDone = (_content is IKnowWhenDone knowWhenDone && knowWhenDone.IsDone);
 
-                if (_content is IKnowWhenDone knowWhenDone && knowWhenDone.IsDone)
-                {
-                    //happens when a chunked response is at the end
-                    break;
-                }
-                else if (read == 0)
+                if (!isDone && (read == 0))
                 {
                     // need to let the native layer get more data
                     Thread.Sleep(10);
                 }
-                else
+                else if (read > 0)
                 {
                     totalRead += read;
                     stream.Write(buffer, 0, read);

--- a/nanoFramework.System.Net.Http/Http/System.Net._InputNetworkStreamWrapper.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net._InputNetworkStreamWrapper.cs
@@ -325,7 +325,8 @@ namespace System.Net
                 {
                     if (0 == RefillInternalBuffer())
                     {
-                        IsDone = IsHttp1_0Completed();  // Handle the 'HTTP/1.0' case
+                        // Handle the 'HTTP/1.0' case
+                        IsDone = IsHttp1_0Completed();
                         return 0;
                     }
 

--- a/nanoFramework.System.Net.Http/Http/System.Net._InputNetworkStreamWrapper.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net._InputNetworkStreamWrapper.cs
@@ -323,7 +323,11 @@ namespace System.Net
                 // then we read into internal buffer. 
                 if (size < read_buffer_size)
                 {
-                    if (0 == RefillInternalBuffer()) return 0;
+                    if (0 == RefillInternalBuffer())
+                    {
+                        IsDone = IsHttp1_0Completed();  // Handle the 'HTTP/1.0' case
+                        return 0;
+                    }
 
                     dataBuffered = m_dataEnd - m_dataStart;
                     if (dataBuffered > 0)
@@ -341,7 +345,15 @@ namespace System.Net
                 }
                 else // Do not replentish internal buffer. Read rest of data directly
                 {
-                    retVal += m_Stream.Read(buffer, offset, size);
+                    int bytesRead = m_Stream.Read(buffer, offset, size);
+                    retVal += bytesRead;
+
+                    // Handle the 'HTTP/1.0' case                    
+                    if ((bytesRead == 0) && IsHttp1_0Completed())
+                    {
+                        IsDone = true;
+                        return retVal;
+                    }
                 }
             }
 
@@ -355,6 +367,20 @@ namespace System.Net
             }
 
             return retVal;
+        }
+
+        /// <summary>
+        /// Returns true if we are in 'HTTP/1.0' mode and the connection has been closed, which marks the end of the body.
+        /// </summary>
+        /// <remarks>
+        /// In 'HTTP/1.0' mode, where the content length is not transmitted in the response header and the server closes the connection to mark the end of the body.
+        /// (see: RFC9112, §6.3, point 8, https://www.rfc-editor.org/rfc/rfc9112#name-message-body-length)
+        /// </remarks>
+        private bool IsHttp1_0Completed()
+        {
+            return
+                (m_BytesLeftInResponse == -1) && !m_EnableChunkedDecoding &&                // We are in HTTP/1.0 mode
+                m_Socket.Poll(1, SelectMode.SelectRead) && (m_Socket.Available == 0);       // The socket is disconnected
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
- Modified `InputNetworkStream.InternalRead()` to detect the cases when in http 1.0 and the connection is closed.
- Reused interface `IKnownWhenDone` (originally only for chunked encoding) to pass the information to the caller (`StreamContent`).
- Modified `StreamContent` to take in account the last bytes returned by `InputNetworkStream.Read()` when `IKnownWhenDone.IsDone == true` (was always 0 with chunked encoding).

## Motivation and Context
Both HttpClient and HttpWebRequest does not handle case where the server does not include a `Content-Length` and closes the connection to mark the end of the body.
- Resolves nanoFramework/Home#1394

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Changes tested against several http servers with an ESP32 in debug mode, using HttpClient and HttpWebRequest.
Response was written to VS output and compared to the response captured using 'Telerik Fiddler'.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
