### PR TITLE
Fix HttpContent.ReadAsStream length, don't buffer StreamContent unelss necessary

### DIFF
--- a/Tests/HttpUnitTests/StreamContentTest.cs
+++ b/Tests/HttpUnitTests/StreamContentTest.cs
@@ -190,6 +190,20 @@ namespace HttpUnitTests
         }
 
         [TestMethod]
+        public void ContentReadStream_GetProperty_LoadIntoBuffer_ReturnOriginalStream()
+        {
+            var source = new MockStream(new byte[10]);
+            var content = new StreamContent(source);
+            content.LoadIntoBuffer();
+
+            Stream stream = content.ReadAsStream();
+            Assert.IsFalse(stream.CanWrite);
+            Assert.AreEqual(source.Length, stream.Length);
+            Assert.AreEqual(0, source.ReadCount);
+            Assert.AreNotSame(source, stream);
+        }
+
+        [TestMethod]
         public void ContentReadStream_GetPropertyPartiallyConsumed_ReturnOriginalStream()
         {
             int consumed = 4;

--- a/Tests/HttpUnitTests/StreamContentTest.cs
+++ b/Tests/HttpUnitTests/StreamContentTest.cs
@@ -177,6 +177,65 @@ namespace HttpUnitTests
         }
 
         [TestMethod]
+        public void CopyTo_NoLoadIntoBuffer_NotBuffered()
+        {
+            var initialSourceContent = new byte[10] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            var sourceContent = new byte[10];
+            Array.Copy(initialSourceContent, sourceContent, 10);
+
+            var sourceStream = new MockStream(sourceContent, true, true);
+
+            var content = new StreamContent(sourceStream);
+
+            var destination1 = new MemoryStream();
+            content.CopyTo(destination1);
+
+            Assert.AreEqual(10, destination1.Length);
+            CollectionAssert.AreEqual(initialSourceContent, destination1.ToArray());
+
+            // replace source content to ensure data was not buffered in the content
+            var replacedSourceContent = new byte[10] { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+            Array.Copy(replacedSourceContent, sourceContent, 10);
+
+            var destination2 = new MemoryStream();
+            content.CopyTo(destination2);
+            Assert.AreEqual(10, destination2.Length);
+            CollectionAssert.AreEqual(replacedSourceContent, destination2.ToArray());
+        }
+
+        [TestMethod]
+        public void CopyTo_LoadIntoBuffer_Buffered()
+        {
+            var initialSourceContent = new byte[10] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            var sourceContent = new byte[10];
+            Array.Copy(initialSourceContent, sourceContent, 10);
+
+            var sourceStream = new MockStream(sourceContent, true, true);
+
+            var content = new StreamContent(sourceStream);
+
+            // buffer so changing the source stream doesn't change the Content
+            content.LoadIntoBuffer();
+
+            var destination1 = new MemoryStream();
+            content.CopyTo(destination1);
+
+            Assert.AreEqual(10, destination1.Length);
+            CollectionAssert.AreEqual(initialSourceContent, destination1.ToArray());
+
+            // replace source content to ensure data was buffered in the content
+            var replacedSourceContent = new byte[10] { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+            Array.Copy(replacedSourceContent, sourceContent, 10);
+
+            var destination2 = new MemoryStream();
+            content.CopyTo(destination2);
+            Assert.AreEqual(10, destination2.Length);
+            CollectionAssert.AreEqual(initialSourceContent, destination2.ToArray());
+        }
+
+        [TestMethod]
         public void ContentReadStream_GetProperty_ReturnOriginalStream()
         {
             var source = new MockStream(new byte[10]);
@@ -234,7 +293,7 @@ namespace HttpUnitTests
             var content = new StreamContent(source);
             Stream contentReadStream = content.ReadAsStream();
 
-            // The following checks verify that the stream returned passes all read-related properties to the 
+            // The following checks verify that the stream returned passes all read-related properties to the
             // underlying MockStream and throws when using write-related members.
 
             Assert.False(contentReadStream.CanWrite);

--- a/nanoFramework.System.Net.Http/Http/HttpClient.cs
+++ b/nanoFramework.System.Net.Http/Http/HttpClient.cs
@@ -309,7 +309,9 @@ namespace System.Net.Http
         /// This operation will block.
         /// </para>
         /// <para>
-        /// This method does not read nor buffer the response body. It will return as soon as the response headers are read.
+        /// As of now, this method reads and buffers the entire response body (see <see cref="StreamContent.SerializeToStream(Stream)"/>).
+        /// If the response needs to be streamed, one of the methods that return <see cref="Send(HttpRequestMessage, HttpCompletionOption)"/> should be used
+        /// with <see cref="HttpCompletionOption.ResponseHeadersRead"/> and <see cref="HttpContent.CopyTo(Stream)"/> instead.
         /// </para>
         /// <para>
         /// This is the .NET nanoFramework equivalent of GetStreamAsync.

--- a/nanoFramework.System.Net.Http/Http/HttpClient.cs
+++ b/nanoFramework.System.Net.Http/Http/HttpClient.cs
@@ -436,7 +436,7 @@ namespace System.Net.Http
             HttpResponseMessage response = base.Send(request);
 
             // Read the content when default HttpCompletionOption.ResponseContentRead is set
-            if (response.Content != null && (completionOption & HttpCompletionOption.ResponseHeadersRead) == 0)
+            if (response.Content != null && completionOption == HttpCompletionOption.ResponseContentRead)
             {
                 response.Content.LoadIntoBuffer();
             }

--- a/nanoFramework.System.Net.Http/Http/HttpClientHandler.cs
+++ b/nanoFramework.System.Net.Http/Http/HttpClientHandler.cs
@@ -238,8 +238,7 @@ namespace System.Net.Http
 
                     var stream = webRequest.GetRequestStream();
 
-                    request.Content.ReadAsStream().CopyTo(stream);
-
+                    request.Content.CopyTo(stream);
                 }
                 else if (MethodHasBody(request.Method))
                 {

--- a/nanoFramework.System.Net.Http/Http/HttpClientHandler.cs
+++ b/nanoFramework.System.Net.Http/Http/HttpClientHandler.cs
@@ -224,14 +224,19 @@ namespace System.Net.Http
                         headers.AddInternal(headerKey, content.Headers._headerStore[headerKey]);
                     }
 
-                    if (request.Headers.TransferEncodingChunked == true)
+                    if (request.Headers.TransferEncodingChunked)
                     {
                         webRequest.SendChunked = true;
                     }
 
                     // set content length
-                    request.Content.TryComputeLength(out long lenght);
-                    webRequest.ContentLength = lenght;
+                    // if it can't be computed and Transfer-Encoding: chunked isn't set,
+                    // webRequest.GetRequestStream throws an exception (so we don't have to validate that here).
+                    if (request.Content.TryComputeLength(out long length))
+                    {
+                        webRequest.ContentLength = length;
+                    }
+
 
                     // set request sent flag
                     _sentRequest = true;

--- a/nanoFramework.System.Net.Http/Http/HttpContent.cs
+++ b/nanoFramework.System.Net.Http/Http/HttpContent.cs
@@ -16,12 +16,11 @@ namespace System.Net.Http
     public abstract class HttpContent : IDisposable
     {
         private HttpContentHeaders _headers;
-        private FixedMemoryStream _buffer;
+        private MemoryStream _buffer;
         private Stream _stream;
 
         private bool _disposed;
 
-        internal const int MaxBufferSize = int.MaxValue;
         internal static readonly Encoding DefaultStringEncoding = Encoding.UTF8;
 
         /// <summary>
@@ -106,7 +105,7 @@ namespace System.Net.Http
                 return _buffer;
             }
 
-            _buffer = new FixedMemoryStream(int.MaxValue);
+            _buffer = new MemoryStream();
 
             SerializeToStream(_buffer);
 
@@ -236,36 +235,5 @@ namespace System.Net.Http
         /// </para>
         /// </remarks>
         protected abstract void SerializeToStream(Stream stream);
-
-        private sealed class FixedMemoryStream : MemoryStream
-        {
-            readonly long _maxSize;
-
-            public FixedMemoryStream(long maxSize)
-                : base()
-            {
-                _maxSize = maxSize;
-            }
-
-            private void CheckOverflow(int count)
-            {
-                if (Length + count > _maxSize)
-                {
-                    throw new HttpRequestException();
-                }
-            }
-
-            public override void WriteByte(byte value)
-            {
-                CheckOverflow(1);
-                base.WriteByte(value);
-            }
-
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                CheckOverflow(count);
-                base.Write(buffer, offset, count);
-            }
-        }
     }
 }

--- a/nanoFramework.System.Net.Http/Http/HttpContent.cs
+++ b/nanoFramework.System.Net.Http/Http/HttpContent.cs
@@ -65,7 +65,9 @@ namespace System.Net.Http
 
             if (_buffer != null)
             {
+                _buffer.Position = 0;
                 _buffer.CopyTo(stream);
+                return;
             }
 
             SerializeToStream(stream);
@@ -111,12 +113,7 @@ namespace System.Net.Http
         /// <exception cref="ObjectDisposedException">If the object has been disposed.</exception>
         public Stream ReadAsStream()
         {
-            LoadIntoBuffer();
-
-            // return a copy so the caller doesn't change the length/position of our internal buffer stream
-            var bufferStream = new MemoryStream(_buffer.GetBuffer());
-            bufferStream.SetLength(_buffer.Length);
-            return bufferStream;
+            return CreateContentReadStream();
         }
 
         /// <summary>
@@ -208,5 +205,23 @@ namespace System.Net.Http
         /// </para>
         /// </remarks>
         protected abstract void SerializeToStream(Stream stream);
+
+        /// <summary>
+        /// If overridden, returns the HTTP content as a stream.
+        /// Otherwise, <see cref="SerializeToStream(Stream)"/> is called.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// <para>
+        /// This is the .NET nanoFramework equivalent of CreateContentReadStreamAsync().
+        /// </para>
+        /// </remarks>
+        protected virtual Stream CreateContentReadStream()
+        {
+            LoadIntoBuffer();
+
+            _buffer.Seek(0, SeekOrigin.Begin);
+            return _buffer;
+        }
     }
 }

--- a/nanoFramework.System.Net.Http/Http/StreamContent.cs
+++ b/nanoFramework.System.Net.Http/Http/StreamContent.cs
@@ -113,8 +113,6 @@ namespace System.Net.Http
                     stream.Write(buffer, 0, read);
                 }
             }
-
-            TotalBytesRead = totalRead;
         }
 
         /// <inheritdoc/>

--- a/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
@@ -1226,7 +1226,7 @@ namespace System.Net
             {
                 if (ContentLength == -1 && SendChunked == false)
                 {
-                    throw new ProtocolViolationException("Content lenght must be present for this request");
+                    throw new ProtocolViolationException("Content length must be present for this request");
                 }
             }
         }


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Remove FixedMemoryStream from HttpContent as the limit is always set to int.MaxValue and MemoryStream is limited to 65535 bytes in NF anyway.
- Fix incorrect length in HttpContent.ReadAsStream().
- Don't do StreamContent buffering if the stream doesn't require it.
- Avoid buffering entire request when sending HTTP request with HttpClient
- Fix typos and small issues
- Add unit tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes incorrect response length when reading HTTP response
- Reduce memory usage during HTTP requests (stream content directly instead of copying)

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added unit tests, though due to the current issues with the test runner I couldn't check if they work.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
