### PR TITLE
Fix `ArgumentOutOfRangeException` when header value is empty

### DIFF
--- a/Tests/HttpUnitTests/HttpUnitTests.nfproj
+++ b/Tests/HttpUnitTests/HttpUnitTests.nfproj
@@ -35,6 +35,7 @@
     <Compile Include="MockContent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UriUnitTests.cs" />
+    <Compile Include="WebHeaderCollectionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.lock.json" />

--- a/Tests/HttpUnitTests/WebHeaderCollectionTests.cs
+++ b/Tests/HttpUnitTests/WebHeaderCollectionTests.cs
@@ -1,0 +1,55 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using nanoFramework.TestFramework;
+using System.Net;
+
+namespace HttpUnitTests
+{
+    [TestClass]
+    public class WebHeaderCollectionTests
+    {
+        [TestMethod]
+        public void Add_Authorization_BearerWithSpaceAndNoValue_ShouldNotThrow()
+        {
+            var headers = new WebHeaderCollection();
+            headers.Add("Authorization: Bearer ");
+        }
+
+        [TestMethod]
+        public void Add_Authorization_NoSpaceSingleChar_ShouldNotThrow()
+        {
+            var headers = new WebHeaderCollection();
+            headers.Add("Authorization: 1");
+        }
+
+        [TestMethod]
+        public void Add_Authorization_ValidBearer_ShouldSucceed()
+        {
+            var headers = new WebHeaderCollection();
+            headers.Add("Authorization: Bearer a11111");
+            string value = headers["Authorization"];
+            Assert.AreEqual("Bearer a11111", value);
+        }
+
+        [TestMethod]
+        public void Add_Authorization_ValidTestValue_ShouldSucceed()
+        {
+            var headers = new WebHeaderCollection();
+            headers.Add("Authorization: test 1");
+            string value = headers["Authorization"];
+            Assert.AreEqual("test 1", value);
+        }
+
+        [TestMethod]
+        public void Add_Authorization_ValidSingleLetterPair_ShouldSucceed()
+        {
+            var headers = new WebHeaderCollection();
+            headers.Add("Authorization: a b");
+            string value = headers["Authorization"];
+            Assert.AreEqual("a b", value);
+        }
+    }
+}

--- a/Tests/HttpUnitTests/WebHeaderCollectionTests.cs
+++ b/Tests/HttpUnitTests/WebHeaderCollectionTests.cs
@@ -12,21 +12,21 @@ namespace HttpUnitTests
     public class WebHeaderCollectionTests
     {
         [TestMethod]
-        public void Add_Authorization_BearerWithSpaceAndNoValue_ShouldNotThrow()
+        public void Add_Authorization_BearerWithSpaceAndNoValue()
         {
             var headers = new WebHeaderCollection();
             headers.Add("Authorization: Bearer ");
         }
 
         [TestMethod]
-        public void Add_Authorization_NoSpaceSingleChar_ShouldNotThrow()
+        public void Add_Authorization_NoSpaceSingleChar()
         {
             var headers = new WebHeaderCollection();
             headers.Add("Authorization: 1");
         }
 
         [TestMethod]
-        public void Add_Authorization_ValidBearer_ShouldSucceed()
+        public void Add_Authorization_ValidBearer()
         {
             var headers = new WebHeaderCollection();
             headers.Add("Authorization: Bearer a11111");
@@ -35,7 +35,7 @@ namespace HttpUnitTests
         }
 
         [TestMethod]
-        public void Add_Authorization_ValidTestValue_ShouldSucceed()
+        public void Add_Authorization_ValidTestValue()
         {
             var headers = new WebHeaderCollection();
             headers.Add("Authorization: test 1");
@@ -44,7 +44,7 @@ namespace HttpUnitTests
         }
 
         [TestMethod]
-        public void Add_Authorization_ValidSingleLetterPair_ShouldSucceed()
+        public void Add_Authorization_ValidSingleLetterPair()
         {
             var headers = new WebHeaderCollection();
             headers.Add("Authorization: a b");
@@ -52,7 +52,7 @@ namespace HttpUnitTests
             Assert.AreEqual("a b", value);
         }
         [TestMethod]
-        public void Add_Authorization_EmptyValue_ShouldNotThrow()
+        public void Add_Authorization_EmptyValue()
         {
             var headers = new WebHeaderCollection();
             headers.Add("Authorization:");
@@ -61,7 +61,7 @@ namespace HttpUnitTests
         }
 
         [TestMethod]
-        public void Add_Authorization_ColonWithSpaceOnly_ShouldNotThrow()
+        public void Add_Authorization_ColonWithSpaceOnly()
         {
             var headers = new WebHeaderCollection();
             headers.Add("Authorization: ");

--- a/Tests/HttpUnitTests/WebHeaderCollectionTests.cs
+++ b/Tests/HttpUnitTests/WebHeaderCollectionTests.cs
@@ -51,5 +51,22 @@ namespace HttpUnitTests
             string value = headers["Authorization"];
             Assert.AreEqual("a b", value);
         }
+        [TestMethod]
+        public void Add_Authorization_EmptyValue_ShouldNotThrow()
+        {
+            var headers = new WebHeaderCollection();
+            headers.Add("Authorization:");
+            string value = headers["Authorization"];
+            Assert.AreEqual(string.Empty, value);
+        }
+
+        [TestMethod]
+        public void Add_Authorization_ColonWithSpaceOnly_ShouldNotThrow()
+        {
+            var headers = new WebHeaderCollection();
+            headers.Add("Authorization: ");
+            string value = headers["Authorization"];
+            Assert.AreEqual(string.Empty, value);
+        }
     }
 }

--- a/Tests/HttpUnitTests/WebHeaderCollectionTests.cs
+++ b/Tests/HttpUnitTests/WebHeaderCollectionTests.cs
@@ -4,6 +4,7 @@
 //
 
 using nanoFramework.TestFramework;
+using System;
 using System.Net;
 
 namespace HttpUnitTests
@@ -67,6 +68,34 @@ namespace HttpUnitTests
             headers.Add("Authorization: ");
             string value = headers["Authorization"];
             Assert.AreEqual(string.Empty, value);
+        }
+
+        [TestMethod]
+        public void Add_NullHeader_ThrowsArgumentNullException()
+        {
+            var headers = new WebHeaderCollection();
+            Assert.ThrowsException(typeof(ArgumentNullException), () => headers.Add(null));
+        }
+
+        [TestMethod]
+        public void Add_EmptyHeader_ThrowsArgumentNullException()
+        {
+            var headers = new WebHeaderCollection();
+            Assert.ThrowsException(typeof(ArgumentNullException), () => headers.Add(string.Empty));
+        }
+
+        [TestMethod]
+        public void Add_HeaderWithNoColon_ThrowsArgumentException()
+        {
+            var headers = new WebHeaderCollection();
+            Assert.ThrowsException(typeof(ArgumentException), () => headers.Add("Authorization"));
+        }
+
+        [TestMethod]
+        public void Add_HeaderNameWithSpace_ThrowsArgumentException()
+        {
+            var headers = new WebHeaderCollection();
+            Assert.ThrowsException(typeof(ArgumentException), () => headers.Add("My Header: value"));
         }
     }
 }

--- a/nanoFramework.System.Net.Http/Http/System.Net.WebHeaders.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net.WebHeaders.cs
@@ -427,7 +427,7 @@ namespace System.Net
             }
 
             string name = header.Substring(0, colpos);
-            // Fix: Check bounds before Substring to prevent ArgumentOutOfRangeException
+            // Handle empty header value
             string value;
             if (colpos + 1 >= header.Length)
             {

--- a/nanoFramework.System.Net.Http/Http/System.Net.WebHeaders.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net.WebHeaders.cs
@@ -427,7 +427,16 @@ namespace System.Net
             }
 
             string name = header.Substring(0, colpos);
-            string value = header.Substring(colpos + 1);
+            // Fix: Check bounds before Substring to prevent ArgumentOutOfRangeException
+            string value;
+            if (colpos + 1 >= header.Length)
+            {
+                value = string.Empty;
+            }
+            else
+            {
+                value = header.Substring(colpos + 1);
+            }
 
             name = CheckBadChars(name, false);
             ThrowOnRestrictedHeader(name);


### PR DESCRIPTION
## Description
- Added bounds check before `Substring` call in `WebHeaderCollection.Add(string header)` method.
- Prevents `ArgumentOutOfRangeException` when header ends with ':' and has no value (e.g., `"Authorization:"`).

## Motivation and Context
- Currently, calling `Add(string header)` with a header string that has no value after the colon (e.g., `"Authorization:"`) causes a crash because `Substring(colpos + 1)` is called without checking bounds.
- This issue was discovered during development of an embedded Web API server (PicoServer.Nano) running on ESP32.

## How Has This Been Tested?
- Manually tested on ESP32 device running nanoFramework using `curl -H "Authorization:" http://<device-ip>/hello`.
- Verified that the exception no longer occurs and the request is handled gracefully.

## Screenshots

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My changes require an update to the documentation.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed.
- [ ] I have added new tests to cover my changes.