### PR TITLE
Fix `ArgumentOutOfRangeException` when validating Basic Authorization header

### DIFF
--- a/Tests/HttpUnitTests/HttpListenerRequest.cs
+++ b/Tests/HttpUnitTests/HttpListenerRequest.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using nanoFramework.TestFramework;
+
+namespace HttpUnitTests
+{
+    internal class HttpListenerRequestTests
+    {
+        // Verifies that malformed Authorization header (no space) does not cause a crash
+        [TestMethod]
+        public void Add_Authorization_NoSpaceMultipleChars_ShouldNotThrow()
+        {
+            var headers = new WebHeaderCollection();
+            headers.Add("Authorization: a111111");
+            string value = headers["Authorization"];
+            Assert.AreEqual("a111111", value);
+        }
+
+        // Verifies that a properly formatted Authorization header (with space) is parsed and stored correctly
+        [TestMethod]
+        public void Add_Authorization_ValidBasicToken_ShouldSucceed()
+        {
+            var headers = new WebHeaderCollection();
+            headers.Add("Authorization: Basic a111111");
+            string value = headers["Authorization"];
+            Assert.AreEqual("Basic a111111", value);
+        }
+    }
+}

--- a/Tests/HttpUnitTests/HttpListenerRequest.cs
+++ b/Tests/HttpUnitTests/HttpListenerRequest.cs
@@ -23,9 +23,9 @@ namespace HttpUnitTests
         public void Add_Authorization_ValidBasicToken_ShouldSucceed()
         {
             var headers = new WebHeaderCollection();
-            headers.Add("Authorization: Basic a111111");
+            headers.Add("Authorization: Basic dXNlcjpwYXNz");
             string value = headers["Authorization"];
-            Assert.AreEqual("Basic a111111", value);
+            Assert.AreEqual("Basic dXNlcjpwYXNz", value);
         }
     }
 }

--- a/Tests/HttpUnitTests/HttpListenerRequestTests.cs
+++ b/Tests/HttpUnitTests/HttpListenerRequestTests.cs
@@ -1,5 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
 
 using System.Net;
 using nanoFramework.TestFramework;

--- a/Tests/HttpUnitTests/HttpUnitTests.nfproj
+++ b/Tests/HttpUnitTests/HttpUnitTests.nfproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="HttpListenerRequest.cs" />
     <Compile Include="HttpUtilityTest.cs" />
     <Compile Include="StreamContentTest.cs" />
     <Compile Include="ByteArrayContentTest.cs" />

--- a/Tests/HttpUnitTests/HttpUnitTests.nfproj
+++ b/Tests/HttpUnitTests/HttpUnitTests.nfproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Compile Include="HttpListenerRequest.cs" />
+    <Compile Include="HttpListenerRequestTests.cs" />
     <Compile Include="HttpUtilityTest.cs" />
     <Compile Include="StreamContentTest.cs" />
     <Compile Include="ByteArrayContentTest.cs" />

--- a/nanoFramework.System.Net.Http/Http/System.Net.HttpListenerRequest.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net.HttpListenerRequest.cs
@@ -206,7 +206,7 @@ namespace System.Net
                 if (headerName == "authorization")
                 {
                     int sepSpace = headerValue.IndexOf(' ');
-                    // Authorization header value must be in format "type credentials". If not, ignore.
+                    // Authorization header value must contain an auth scheme followed by a space and its parameter(s), e.g. "Basic xxx" or "Bearer xxx". If not, ignore.
                     if (sepSpace > 0)
                     {
                         string authType = headerValue.Substring(0, sepSpace);

--- a/nanoFramework.System.Net.Http/Http/System.Net.HttpListenerRequest.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net.HttpListenerRequest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
@@ -206,21 +206,26 @@ namespace System.Net
                 if (headerName == "authorization")
                 {
                     int sepSpace = headerValue.IndexOf(' ');
-                    string authType = headerValue.Substring(0, sepSpace);
-                    if (authType.ToLower() == "basic")
+                    // Authorization header value must be in format "type credentials". If not, ignore.
+                    if (sepSpace > 0)
                     {
-                        string authInfo = headerValue.Substring(sepSpace + 1);
-                        // authInfo is base64 encoded username and password.
-                        byte[] authInfoDecoded = Convert.FromBase64String(authInfo);
-                        char[] authInfoDecChar = System.Text.Encoding.UTF8.GetChars(authInfoDecoded);
-                        string strAuthInfo = new string(authInfoDecChar);
-                        // The strAuthInfo comes in format username:password. Parse it.
-                        int sepColon = strAuthInfo.IndexOf(':');
-                        if (sepColon != -1)
+                        string authType = headerValue.Substring(0, sepSpace);
+                        if (authType.ToLower() == "basic")
                         {
-                            m_NetworkCredentials = new NetworkCredential(strAuthInfo.Substring(0, sepColon), strAuthInfo.Substring(sepColon + 1));
+                            string authInfo = headerValue.Substring(sepSpace + 1);
+                            // authInfo is base64 encoded username and password.
+                            byte[] authInfoDecoded = Convert.FromBase64String(authInfo);
+                            char[] authInfoDecChar = System.Text.Encoding.UTF8.GetChars(authInfoDecoded);
+                            string strAuthInfo = new string(authInfoDecChar);
+                            // The strAuthInfo comes in format username:password. Parse it.
+                            int sepColon = strAuthInfo.IndexOf(':');
+                            if (sepColon != -1)
+                            {
+                                m_NetworkCredentials = new NetworkCredential(strAuthInfo.Substring(0, sepColon), strAuthInfo.Substring(sepColon + 1));
+                            }
                         }
                     }
+
                 }
             }
 


### PR DESCRIPTION
Fix crash when Authorization validation for Basic format

## Description
- Fixed an `ArgumentOutOfRangeException` crash in `HttpListenerRequest.ParseHTTPRequest` when the `Authorization` header value does not contain a space (e.g., `Authorization: a111111` or malformed Basic authentication).
- Added a safety check `if (sepSpace > 0)` before parsing the Authorization header value.
- If the value does not contain a space, the header is silently ignored.

## Motivation and Context
- Currently, when a malformed Authorization header without space is received (e.g., `Authorization: a111111`), the `ParseHTTPRequest` method crashes with `ArgumentOutOfRangeException` because `sepSpace` is -1 and `Substring(0, sepSpace)` is called.
- This issue was discovered during development of PicoServer.Nano when testing edge cases with malformed Authorization headers.

## How Has This Been Tested?
- Manually tested on ESP32 device using `curl -H "Authorization: a111111" http://<device-ip>/hello`
- Verified that no exception is thrown and the request is handled gracefully
- Added unit test `Add_Authorization_NoSpaceMultipleChars_ShouldNotThrow` in `HttpListenerRequestTests.cs`

## Screenshots

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.